### PR TITLE
fix(network): correct DNS response type to string[]

### DIFF
--- a/js/kubewarden/host_capabilities/network.ts
+++ b/js/kubewarden/host_capabilities/network.ts
@@ -5,9 +5,9 @@ export namespace Network {
    * Represents the response of a DNS lookup operation.
    */
   export class DnsLookupResponse {
-    ips: [string];
+    ips: string[];
 
-    constructor(ips: [string]) {
+    constructor(ips: string[]) {
       this.ips = ips;
     }
   }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
The `ips` field in `DnsLookupResponse` was incorrectly typed as a single-element tuple (`[string]`), which enforced exactly one IP address.  
This PR aligns the type with the [specification](https://docs.kubewarden.io/reference/spec/host-capabilities/net#wapc-function---v1dns_lookup_host-output), which defines it as a list of ips. (`string[]` array)

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
