### PR TITLE
chore(deps): update to latest stable release of Rust

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
           set -e
 
           INSTALL_DIR=$HOME/.javy
-          VERSION="v5.0.1"
+          VERSION="v5.0.4"
 
           mkdir -p $INSTALL_DIR
           curl -sL https://github.com/bytecodealliance/javy/releases/download/${VERSION}/javy-x86_64-linux-${VERSION}.gz -o $INSTALL_DIR/javy.gz

--- a/javy-plugin-kubewarden/rust-toolchain.toml
+++ b/javy-plugin-kubewarden/rust-toolchain.toml
@@ -1,5 +1,5 @@
 
 [toolchain]
-channel    = "1.81.0"
+channel = "1.86.0"
 components = ["clippy", "rust-analyzer", "rustfmt"]
-targets    = ["wasm32-wasip1"]
+targets = ["wasm32-wasip1"]


### PR DESCRIPTION
Previously, we were stuck with an older version of Rust due to some incompatibility issues with javy.

The incompatibility issues were caused by a change introduced by Rust 1.82.0 (see [this blog post](https://blog.rust-lang.org/2024/09/24/webassembly-targets-change-in-default-target-features/)).

More specifically:

> When putting all of this together, it means that with LLVM 19, which has the reference-types feature enabled by default,
> any WebAssembly module with an indirect function call (which is almost always the case for Rust code)
> will produce a WebAssembly binary that cannot be decoded by engines and tooling that do not support the reference-types proposal.
> It is expected that this change will have a low impact due to the age of the reference-types proposal and breadth of
> implementation in engines. Given the multitude of WebAssembly engines, however, it's recommended that any WebAssembly users test out
> Rust 1.82 beta and see if the produced module still runs on their engine of choice.

That forced us to keep using Rust 1.81.
