### PR TITLE
chore(deps): update javy rust crate and update renovatebot config

### DIFF
--- a/javy-plugin-kubewarden/Cargo.toml
+++ b/javy-plugin-kubewarden/Cargo.toml
@@ -8,4 +8,4 @@ crate-type = ["cdylib"]
 name = "javy_plugin_kubewarden"
 
 [dependencies]
-javy-plugin-api = "3.0"
+javy-plugin-api = "3.1"

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>kubewarden/github-actions//renovate-config/policies"]
+  "extends": [
+    "github>kubewarden/github-actions//renovate-config/policies"
+  ],
+  "packageRules": [
+    {
+      "matchPaths": [
+        "javy-plugin-kubewarden/**"
+      ],
+      "matchManagers": [
+        "cargo"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Update the `javy` crate to the latest version. renovatebot wasn't probably aware of the Rust project due to being inside of a subfolder. This should have been fixed now.
