### PR TITLE
ci: Rename Rust linters job

### DIFF
--- a/.github/workflows/javy-plugin.yml
+++ b/.github/workflows/javy-plugin.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: linters
+      - name: rust linters
         run: |
           cd javy-plugin-kubewarden
           cargo fmt --all -- --check


### PR DESCRIPTION
## Description

After adding the `lint` job for JS, we would have both a `lint` and a `linters` job. Be more specific about the Rust linters job.
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
