### PR TITLE
ci: Rename the actual job for rust-linters

### DIFF
--- a/.github/workflows/javy-plugin.yml
+++ b/.github/workflows/javy-plugin.yml
@@ -10,7 +10,7 @@ on:
 
 name: Javy plugin
 jobs:
-  linters:
+  rust-linters:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION

## Description


The previous PR renamed the step, not the job, which is what appears on GH UI.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
