### PR TITLE
feat(ci): add continuous delivery workflows and first alpha release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,66 @@
+categories:
+  - title: '⚠️  Breaking changes'
+    labels:
+      - 'kind/major'
+      - 'kind/breaking-change'
+  - title: '🚀 Features'
+    labels:
+      - 'kind/enhancement'
+      - 'kind/feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'kind/bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'kind/chore'
+      - 'area/dependencies'
+
+exclude-labels:
+  - duplicate
+  - invalid
+  - later
+  - wontfix
+  - kind/question
+  - release/skip-changelog
+
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+name-template: 'v$RESOLVED_VERSION'
+template: |
+  $CHANGES
+
+autolabeler:
+  # Tag any PR with "!" in the subject as major update. In other words, breaking change
+  - label: 'kind/breaking-change'
+    title: '/.*!:.*/'
+  - label: 'area/dependencies'
+    title: 'chore(deps)'
+  - label: 'area/dependencies'
+    title: 'fix(deps)'
+  - label: 'area/dependencies'
+    title: 'build(deps)'
+  - label: 'kind/feature'
+    title: 'feat'
+  - label: 'kind/bug'
+    title: 'fix'
+  - label: 'kind/chore'
+    title: 'chore'
+
+version-resolver:
+  major:
+    labels:
+      - 'kind/major'
+      - 'kind/breaking-change'
+  minor:
+    labels:
+      - 'kind/minor'
+      - 'kind/feature'
+      - 'kind/enhancement'
+  patch:
+    labels:
+      - 'kind/patch'
+      - 'kind/fix'
+      - 'kind/bug'
+      - 'kind/chore'
+      - 'area/dependencies'
+  default: patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on: 
+  - push
+  - pull_request
+  - workflow_call
+  
 name: CI
 jobs:
   lint:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on: 
+  - push
+  - pull_request
+  - workflow_call
+  
 name: Continuous integration
 jobs:
   e2e-tests:

--- a/.github/workflows/javy-plugin.yml
+++ b/.github/workflows/javy-plugin.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - 'javy-plugin-kubewarden/**'
       - '.github/workflows/**'
-  workflow_call:
 
 name: Javy plugin
 jobs:

--- a/.github/workflows/javy-plugin.yml
+++ b/.github/workflows/javy-plugin.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'javy-plugin-kubewarden/**'
       - '.github/workflows/**'
+  workflow_call:
 
 name: Javy plugin
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,11 @@ jobs:
     uses: ./.github/workflows/ci.yml
   e2e: 
     uses: ./.github/workflows/e2e-tests.yml
-  javy-plugin:
-    uses: ./.github/workflows/javy-plugin.yml
 
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs: [ci, e2e, javy-plugin]
+    needs: [ci, e2e]
     steps:
       - name: Retrieve tag name
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -56,7 +54,7 @@ jobs:
   publish:
     name: Publish on npm
     runs-on: ubuntu-latest
-    needs: [ci, e2e, javy-plugin]
+    needs: [ci, e2e]
     permissions:
       contents: read
       id-token: write # Required for npm provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  ci:
+    # A branch is required, and cannot be dynamic - https://github.com/actions/runner/issues/1493
+    uses: ./.github/workflows/ci.yml
+  e2e: 
+    uses: ./.github/workflows/e2e-tests.yml
+  javy-plugin:
+    uses: ./.github/workflows/javy-plugin.yml
+
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    needs: [ci, e2e, javy-plugin]
+    steps:
+      - name: Retrieve tag name
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo TAG_NAME=$(echo ${{ github.ref_name }}) >> $GITHUB_ENV
+      - name: Get release ID from the release created by release drafter
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            let releases = await github.rest.repos.listReleases({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+            });
+            for (const release of releases.data) {
+              if (release.draft) {
+                      core.info(release)
+                      core.exportVariable('RELEASE_ID', release.id)
+                      return
+              }
+            }
+            core.setFailed(`Draft release not found`)
+      - name: Publish release
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const {RELEASE_ID} = process.env
+            const {TAG_NAME} = process.env
+            github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: `${RELEASE_ID}`,
+              draft: false,
+              tag_name: `${TAG_NAME}`,
+              name: `${TAG_NAME}`,
+              prerelease: `${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}`
+            });
+  
+  publish:
+    name: Publish on npm
+    runs-on: ubuntu-latest
+    needs: [ci, e2e, javy-plugin]
+    permissions:
+      contents: read
+      id-token: write # Required for npm provenance
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      
+      - name: Install dependencies
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@4da9b3a995e38a7821d404dee64d9559c29bb9c0 # v4.5.3
+
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install npm dependencies in js directory
+        run: |
+          cd js
+          npm ci
+      
+      - name: Build package
+        run: |
+          cd js
+          npm run build
+      
+      - name: Publish to npm
+        run: |
+          cd js
+          npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/js/index.ts
+++ b/js/index.ts
@@ -1,0 +1,15 @@
+// Kubewarden Policy SDK for JavaScript/ TypeScript
+// Main entry point that exports all SDK functionality
+
+// Core SDK modules
+export * from './kubewarden/admission';
+export * from './kubewarden/validation';
+
+// Host capabilities
+export * from './kubewarden/host_capabilities';
+
+// Constants
+export * from './kubewarden/constants/constants';
+
+// Protocol definitions
+export * from './protocol';

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -27,7 +27,8 @@
         "typescript-eslint": "^8.26.0",
         "webpack": "^5.97.1",
         "webpack-cli": "^6.0.1"
-      }
+      },
+      "version": "0.1.0-alpha.0"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -9567,5 +9568,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     }
-  }
+  },
+  "version": "0.1.0-alpha.0"
 }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "policy-sdk-js-test",
-  "version":"0.1.0-alpha.4",
+  "version":"0.1.0-alpha.8",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/js/package.json
+++ b/js/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "policy-sdk-js-test",
-  "version":"0.1.0-alpha.8",
+  "name": "policy-sdk-js",
+  "version": "0.1.0-alpha.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/"
   ],
   "repository": {
-  "type": "git",
-  "url": "https://github.com/esosaoh/policy-sdk-js.git"
+    "type": "git",
+    "url": "https://github.com/kubewarden/policy-sdk-js.git"
   },
   "dependencies": {
     "kubernetes-types": "^1.30.0"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,11 @@
 {
   "name": "policy-sdk-js-test",
-  "version":"0.1.0-alpha.1",
+  "version":"0.1.0-alpha.2",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/"
+  ],
   "dependencies": {
     "kubernetes-types": "^1.30.0"
   },

--- a/js/package.json
+++ b/js/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "policy-sdk-js",
+  "name": "policy-sdk-js-test",
+  "version":"0.1.0-alpha.1",
   "dependencies": {
     "kubernetes-types": "^1.30.0"
   },

--- a/js/package.json
+++ b/js/package.json
@@ -1,11 +1,15 @@
 {
   "name": "policy-sdk-js-test",
-  "version":"0.1.0-alpha.2",
+  "version":"0.1.0-alpha.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/"
   ],
+  "repository": {
+  "type": "git",
+  "url": "https://github.com/esosaoh/policy-sdk-js.git"
+  },
   "dependencies": {
     "kubernetes-types": "^1.30.0"
   },

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   mode: 'production',
-  entry: './demo_policy/main.ts',
+  entry: './index.ts',
   module: {
     rules: [
       {


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #148 
This PR introduces a Continuous Delivery (CD) pipeline for alpha releases

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Continuous Delivery has been validated on my fork:
- **Test Release**: [v0.1.0-alpha.8](https://github.com/esosaoh/policy-sdk-js/releases/tag/v0.1.0-alpha.8)
- **Successful Workflow Run**: [View Actions Log](https://github.com/esosaoh/policy-sdk-js/actions/runs/16438297038)

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information
- A granular access token from npm (`NPM_TOKEN`) is needed as a repository secret if not already set up

