### PR TITLE
feat: add new check-plugin target and use it in prepublishOnly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Install dependencies
         uses: kubewarden/github-actions/policy-gh-action-dependencies@17f4dbf90d74f26892f7cc18179d08c4d63914d9 # v4.5.4
 
+      - name: Build Javy plugin
+        run: make build-plugin 
+
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/js/Makefile
+++ b/js/Makefile
@@ -9,3 +9,11 @@ unit-tests:
 
 clean:
 	rm -rf node_modules dist
+
+check-plugin:
+	@echo "Checking if plugin files exist..."
+	@if [ ! -f "./plugin/javy-plugin-kubewarden.wasm" ]; then \
+		echo "Error: Plugin file './plugin/javy-plugin-kubewarden.wasm' not found. Run 'make build-plugin' from root directory first."; \
+		exit 1; \
+	fi
+	@echo "Plugin file found ✓"

--- a/js/package.json
+++ b/js/package.json
@@ -49,7 +49,6 @@
     "build": "npm run build:lib && npm run build:types",
     "build:lib": "webpack",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
-    "prepublishOnly": "make build-plugin",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/js/package.json
+++ b/js/package.json
@@ -49,6 +49,7 @@
     "build": "npm run build:lib && npm run build:types",
     "build:lib": "webpack",
     "build:types": "tsc --emitDeclarationOnly --outDir dist",
+    "prepublishOnly": "make check-plugin",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",


### PR DESCRIPTION
## Description

- Add check-plugin target to js/Makefile to verify plugin exists
- Update prepublishOnly script to use check-plugin instead of build-plugin
- Prevents npm publish if javy-plugin-kubewarden.wasm is missing
