### PR TITLE
Add policy logging API

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The policy requires the following tools to be installed on the host machine:
 
 ## Plugin Location
 
-When you install the SDK as a dependency in your project, the plugin will be available at: `node_modules/kubewarden-policy-sdk/js/plugin/`
+When you install the SDK as a dependency in your project, the plugin will be available at: `node_modules/@kubewarden/policy-sdk/plugin/`
 
 This is the path you'll need to reference when building policies that use this SDK.
 

--- a/demo_policy/main.ts
+++ b/demo_policy/main.ts
@@ -1,3 +1,4 @@
+import { Logging } from '../js/kubewarden/logging';
 import { Validation } from '../js/kubewarden/validation';
 import { writeOutput } from '../js/protocol';
 
@@ -34,6 +35,12 @@ import {
 
 declare function policyAction(): string;
 
+const LOG_CONTEXT = 'demo-policy';
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Validates a Kubernetes admission request to ensure that privileged containers
  * are not allowed unless they are in an ignored namespace.
@@ -44,7 +51,7 @@ function validate() {
   const settings = validationRequest.settings as PolicySettings;
   let response: Validation.ValidationResponse;
 
-  console.error('Settings:', JSON.stringify(settings));
+  Logging.debug(LOG_CONTEXT, 'Settings loaded', { settings });
 
   switch (settings.testScenario) {
     case 'oci-manifest-digest-success': {
@@ -167,7 +174,7 @@ function validateSettings() {
     const response = settings.validate();
     writeOutput(response);
   } catch (err) {
-    console.error('validateSettings error:', err);
+    Logging.error(LOG_CONTEXT, 'validateSettings error', { error: errorMessage(err) });
     const response = new Validation.SettingsValidationResponse(false, `${err}`);
     writeOutput(response);
   }
@@ -175,7 +182,7 @@ function validateSettings() {
 
 try {
   const action = policyAction();
-  console.error('Action:', action);
+  Logging.debug(LOG_CONTEXT, 'Policy action selected', { action });
 
   switch (action) {
     case 'validate': {
@@ -187,13 +194,13 @@ try {
       break;
     }
     default: {
-      console.error('Unknown action:', action);
+      Logging.error(LOG_CONTEXT, 'Unknown policy action', { action });
       const response = new Validation.ValidationResponse(false, 'wrong invocation');
       writeOutput(response);
     }
   }
 } catch (error) {
-  console.error('error:', error);
+  Logging.error(LOG_CONTEXT, 'Policy invocation failed', { error: errorMessage(error) });
   const response = new Validation.ValidationResponse(false, 'wrong invocation');
   writeOutput(response);
 }

--- a/demo_policy/test_scenarios.ts
+++ b/demo_policy/test_scenarios.ts
@@ -10,9 +10,12 @@ import { Manifest } from '../js/kubewarden/host_capabilities/oci/manifest/manife
 import { ManifestConfig } from '../js/kubewarden/host_capabilities/oci/manifest_config/manifest_config';
 import { ManifestDigest } from '../js/kubewarden/host_capabilities/oci/manifest_digest/manifest_digest';
 import { OciSignatureVerifier } from '../js/kubewarden/host_capabilities/oci/verify_v2/verifier';
+import { Logging } from '../js/kubewarden/logging';
 import { Validation } from '../js/kubewarden/validation';
 
 import type { PolicySettings } from './policy_settings';
+
+const LOG_CONTEXT = 'demo-policy';
 
 /**
  * Handles OCI manifest digest lookup success scenario
@@ -110,7 +113,9 @@ export function handlePrivilegedContainerValidation(
   settings: PolicySettings,
 ): Validation.ValidationResponse {
   if (settings.ignoredNamespaces?.includes(validationRequest.request.namespace || '')) {
-    console.error('Privileged containers are allowed inside of ignored namespace');
+    Logging.info(LOG_CONTEXT, 'Privileged containers are allowed inside ignored namespace', {
+      namespace: validationRequest.request.namespace || '',
+    });
     return Validation.acceptRequest();
   }
 

--- a/js/README.md
+++ b/js/README.md
@@ -1,6 +1,6 @@
 [![Sandbox](https://img.shields.io/badge/status-sandbox-red?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#sandbox)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache2.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
-[![npm version](https://badge.fury.io/js/kubewarden-policy-sdk.svg)](https://www.npmjs.com/package/kubewarden-policy-sdk)
+[![npm version](https://img.shields.io/npm/v/@kubewarden/policy-sdk)](https://www.npmjs.com/package/@kubewarden/policy-sdk)
 
 # Kubewarden Policy SDK for JavaScript/TypeScript
 
@@ -12,7 +12,7 @@ The official JavaScript/TypeScript SDK for writing [Kubewarden](https://kubeward
 ## Installation
 
 ```bash
-npm install kubewarden-policy-sdk
+npm install @kubewarden/policy-sdk
 ```
 
 ## Quick Start
@@ -20,7 +20,7 @@ npm install kubewarden-policy-sdk
 ### Basic Policy Structure
 
 ```typescript
-import { Validation, writeOutput } from 'kubewarden-policy-sdk';
+import { Validation, writeOutput } from '@kubewarden/policy-sdk';
 
 function validate() {
   // Read the admission request
@@ -50,28 +50,36 @@ function validate() {
 ### Using Host Capabilities
 
 > [!IMPORTANT]  
-> Logging to `stdout` will break your policy. Always use `console.error()` for logging instead of `console.log()` to avoid policy failures.
+> Logging to `stdout` or `stderr` will break your policy. Use the SDK logging API instead.
+
+```typescript
+import { Logging } from '@kubewarden/policy-sdk';
+
+Logging.info('example-policy', 'request accepted', {
+  namespace: 'default',
+});
+```
 
 The SDK provides access to Kubewarden's host capabilities:
 
 #### Network Operations
 
 ```typescript
-import { hostCapabilities } from 'kubewarden-policy-sdk';
+import { Logging, hostCapabilities } from '@kubewarden/policy-sdk';
 
 // DNS lookup
 const dnsResult = hostCapabilities.Net.lookupHost('example.com');
-console.error('IPs:', dnsResult.ips);
+Logging.info('example-policy', 'DNS lookup completed', { ips: dnsResult.ips });
 ```
 
 #### OCI Registry Operations
 
 ```typescript
-import { hostCapabilities } from 'kubewarden-policy-sdk';
+import { Logging, hostCapabilities } from '@kubewarden/policy-sdk';
 
 // Get OCI manifest
 const manifest = hostCapabilities.OciManifest.getManifest('registry.io/image:tag');
-console.error('Manifest:', manifest);
+Logging.debug('example-policy', 'OCI manifest fetched', { manifest });
 
 // Verify image signatures
 const verificationResult = hostCapabilities.OciSignatureVerifier.verifyPubKeysImage(
@@ -83,7 +91,7 @@ const verificationResult = hostCapabilities.OciSignatureVerifier.verifyPubKeysIm
 #### Kubernetes API Access
 
 ```typescript
-import { hostCapabilities } from 'kubewarden-policy-sdk';
+import { hostCapabilities } from '@kubewarden/policy-sdk';
 
 // Get a Kubernetes resource
 const resource = hostCapabilities.Kubernetes.getResource({
@@ -104,7 +112,7 @@ const pods = hostCapabilities.Kubernetes.listResourcesByNamespace({
 #### Cryptographic Operations
 
 ```typescript
-import { hostCapabilities } from 'kubewarden-policy-sdk';
+import { hostCapabilities } from '@kubewarden/policy-sdk';
 
 // Verify certificate
 const cert = hostCapabilities.Crypto.CertificateUtils.fromString(
@@ -122,7 +130,7 @@ const verificationResult = hostCapabilities.Crypto.verifyCert(
 ### Complete Example Policy
 
 ```typescript
-import { Validation, writeOutput } from 'kubewarden-policy-sdk';
+import { Validation, writeOutput } from '@kubewarden/policy-sdk';
 import type { Pod } from 'kubernetes-types/core/v1';
 
 interface PolicySettings {
@@ -185,6 +193,11 @@ new ValidationResponse(
 
 Reads and parses the incoming Kubernetes admission request.
 
+### Logging
+
+- `Logging.log(level: Logging.Level, context: string, message: string, fields?: Record<string, unknown>)`: Send a structured log entry to the Kubewarden host.
+- `Logging.trace`, `Logging.debug`, `Logging.info`, `Logging.warn`, `Logging.error`: Convenience helpers for supported log levels.
+
 ### Host Capabilities
 
 #### Network
@@ -232,7 +245,7 @@ For complete documentation of all available host capabilities, see the [Kubeward
 1. **Install the SDK**:
 
    ```bash
-   npm install kubewarden-policy-sdk
+   npm install @kubewarden/policy-sdk
    ```
 
 2. **Write your policy** (e.g., `main.ts`)
@@ -256,7 +269,7 @@ For complete documentation of all available host capabilities, see the [Kubeward
 The Javy plugin required for compilation is included in the package at:
 
 ```
-node_modules/kubewarden-policy-sdk/plugin/javy-plugin-kubewarden.wasm
+node_modules/@kubewarden/policy-sdk/plugin/javy-plugin-kubewarden.wasm
 ```
 
 ## Testing

--- a/js/README.md
+++ b/js/README.md
@@ -68,7 +68,7 @@ The SDK provides access to Kubewarden's host capabilities:
 import { Logging, hostCapabilities } from '@kubewarden/policy-sdk';
 
 // DNS lookup
-const dnsResult = hostCapabilities.Net.lookupHost('example.com');
+const dnsResult = hostCapabilities.Network.dnsLookup('example.com');
 Logging.info('example-policy', 'DNS lookup completed', { ips: dnsResult.ips });
 ```
 
@@ -78,7 +78,7 @@ Logging.info('example-policy', 'DNS lookup completed', { ips: dnsResult.ips });
 import { Logging, hostCapabilities } from '@kubewarden/policy-sdk';
 
 // Get OCI manifest
-const manifest = hostCapabilities.OciManifest.getManifest('registry.io/image:tag');
+const manifest = hostCapabilities.Manifest.getOCIManifest('registry.io/image:tag');
 Logging.debug('example-policy', 'OCI manifest fetched', { manifest });
 
 // Verify image signatures
@@ -115,7 +115,7 @@ const pods = hostCapabilities.Kubernetes.listResourcesByNamespace({
 import { hostCapabilities } from '@kubewarden/policy-sdk';
 
 // Verify certificate
-const cert = hostCapabilities.Crypto.CertificateUtils.fromString(
+const cert = hostCapabilities.CertificateUtils.fromString(
   '-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----',
   'Pem',
 );
@@ -202,31 +202,31 @@ Reads and parses the incoming Kubernetes admission request.
 
 #### Network
 
-- `lookupHost(hostname: string)`: DNS resolution
+- `Network.dnsLookup(hostname: string)`: DNS resolution
 
 #### Container Registry
 
-- `getManifest(image: string)`: Get OCI manifest
-- `getManifestConfig(image: string)`: Get manifest configuration
-- `getManifestDigest(image: string)`: Get manifest digest
+- `Manifest.getOCIManifest(image: string)`: Get OCI manifest
+- `ManifestConfig.getOCIManifestAndConfig(image: string)`: Get manifest configuration
+- `ManifestDigest.getOCIManifestDigest(image: string)`: Get manifest digest
 
 #### Signature Verifier
 
-- `verifyPubKeysImage(image: string, pubKeys: string[])`: Verify with public keys
-- `verifyKeylessExactMatch(image: string, keyless: KeylessInfo[])`: Keyless verification
-- `verifyKeylessPrefix(image: string, keyless: KeylessPrefixInfo[])`: Prefix-based keyless verification
-- `verifyGithubActions(image: string, owner: string)`: GitHub Actions verification
+- `OciSignatureVerifier.verifyPubKeysImage(image: string, pubKeys: string[])`: Verify with public keys
+- `OciSignatureVerifier.verifyKeylessExactMatch(image: string, keyless: KeylessInfo[])`: Keyless verification
+- `OciSignatureVerifier.verifyKeylessPrefixMatch(image: string, keyless: KeylessPrefixInfo[])`: Prefix-based keyless verification
+- `OciSignatureVerifier.verifyKeylessGithubActions(image: string, owner: string)`: GitHub Actions verification
 
 #### Kubernetes
 
-- `getResource(request: GetResourceRequest)`: Get a specific resource
-- `listResourcesByNamespace(request: ListResourcesRequest)`: List resources in namespace
-- `listAllResources(request: ListResourcesRequest)`: List all resources
-- `canI(request: CanIRequest)`: Check permissions using the Kubernetes authorization API
+- `Kubernetes.getResource(request: GetResourceRequest)`: Get a specific resource
+- `Kubernetes.listResourcesByNamespace(request: ListResourcesRequest)`: List resources in namespace
+- `Kubernetes.listAllResources(request: ListResourcesRequest)`: List all resources
+- `Kubernetes.canI(request: CanIRequest)`: Check permissions using the Kubernetes authorization API
 
 #### Cryptographic
 
-- `verifyCert(cert: Certificate, certChain: Certificate[], notAfter?: string)`: Verify certificates
+- `Crypto.verifyCert(cert: Certificate, certChain: Certificate[], notAfter?: string)`: Verify certificates
 - `CertificateUtils.fromString(certString: string, encoding: CertificateEncoding)`: Create certificate from string
 - `CertificateUtils.toString(cert: Certificate)`: Convert certificate to string
 

--- a/js/index.ts
+++ b/js/index.ts
@@ -3,6 +3,7 @@
 import * as admission from './kubewarden/admission';
 import * as constants from './kubewarden/constants/constants';
 import * as hostCapabilities from './kubewarden/host_capabilities';
+import * as logging from './kubewarden/logging';
 import * as validation from './kubewarden/validation';
 import * as protocol from './protocol';
 
@@ -11,6 +12,7 @@ const exported = {
   admission,
   validation,
   hostCapabilities,
+  logging,
   constants,
   protocol,
 };
@@ -23,5 +25,7 @@ export { protocol };
 export { admission };
 export { constants };
 export { hostCapabilities };
+export { logging };
+export { Logging } from './kubewarden/logging';
 
 export const { writeOutput } = protocol;

--- a/js/kubewarden/admission.ts
+++ b/js/kubewarden/admission.ts
@@ -89,9 +89,9 @@ export namespace KubernetesAdmission {
    * @example
    * ```typescript
    * const gvk = new GroupVersionKind("apps", "v1", "Deployment");
-   * console.log(gvk.group); // "apps"
-   * console.log(gvk.version); // "v1"
-   * console.log(gvk.kind); // "Deployment"
+   * const group = gvk.group; // "apps"
+   * const version = gvk.version; // "v1"
+   * const kind = gvk.kind; // "Deployment"
    * ```
    *
    * @public
@@ -116,9 +116,9 @@ export namespace KubernetesAdmission {
    * @example
    * ```typescript
    * const gvr = new GroupVersionResource('apps', 'v1', 'deployments');
-   * console.log(gvr.group); // 'apps'
-   * console.log(gvr.version); // 'v1'
-   * console.log(gvr.resource); // 'deployments'
+   * const group = gvr.group; // 'apps'
+   * const version = gvr.version; // 'v1'
+   * const resource = gvr.resource; // 'deployments'
    * ```
    *
    * @public

--- a/js/kubewarden/host_capabilities/crypto/crypto.test.ts
+++ b/js/kubewarden/host_capabilities/crypto/crypto.test.ts
@@ -1,10 +1,10 @@
-import { HostCall } from '../';
+import { HostCall } from '../host_call';
 
 import { Crypto } from './crypto';
 import type { Certificate, CertificateVerificationResponse } from './types';
 
 // Mock the HostCall
-jest.mock('../', () => ({
+jest.mock('../host_call', () => ({
   HostCall: {
     hostCall: jest.fn(),
   },

--- a/js/kubewarden/host_capabilities/crypto/crypto.ts
+++ b/js/kubewarden/host_capabilities/crypto/crypto.ts
@@ -1,4 +1,4 @@
-import { HostCall } from '../';
+import { HostCall } from '../host_call';
 
 import type { Certificate, CertificateVerificationResponse } from './types';
 import { CertificateUtils } from './types';

--- a/js/kubewarden/host_capabilities/host_call.ts
+++ b/js/kubewarden/host_capabilities/host_call.ts
@@ -1,0 +1,33 @@
+import { readInput } from '../../protocol';
+
+// this function is provided by the Kubewarden Javy plugin
+declare function __hostCall(binding: string, ns: string, op: string, payload: ArrayBuffer): boolean;
+
+export namespace HostCall {
+  /**
+   * Makes a host call with the specified binding, namespace, operation, and payload.
+   *
+   * @param {string} binding - The binding to use for the host call.
+   * @param {string} ns - The namespace for the host call.
+   * @param {string} op - The operation to perform in the host call.
+   * @param {ArrayBuffer} payload - The payload to send with the host call.
+   * @returns {Uint8Array} - The response from the host call.
+   * @throws {Error} - Throws an error if the host call is unsuccessful.
+   */
+  export function hostCall(
+    binding: string,
+    ns: string,
+    op: string,
+    payload: ArrayBuffer,
+  ): Uint8Array {
+    const isSuccessful = __hostCall(binding, ns, op, payload);
+    const response = readInput();
+
+    if (!isSuccessful) {
+      const responseText = new TextDecoder('utf-8').decode(response);
+      throw new Error(`Host call failed: ${responseText}`);
+    }
+
+    return response;
+  }
+}

--- a/js/kubewarden/host_capabilities/host_call.ts
+++ b/js/kubewarden/host_capabilities/host_call.ts
@@ -25,7 +25,9 @@ export namespace HostCall {
 
     if (!isSuccessful) {
       const responseText = new TextDecoder('utf-8').decode(response);
-      throw new Error(`Host call failed: ${responseText}`);
+      throw new Error(
+        `Host call failed (binding: ${binding}, ns: ${ns}, op: ${op}): ${responseText}`,
+      );
     }
 
     return response;

--- a/js/kubewarden/host_capabilities/index.test.ts
+++ b/js/kubewarden/host_capabilities/index.test.ts
@@ -1,0 +1,25 @@
+import {
+  CertificateUtils,
+  Crypto,
+  HostCall,
+  Kubernetes,
+  Manifest,
+  ManifestConfig,
+  ManifestDigest,
+  Network,
+  OciSignatureVerifier,
+} from './index';
+
+describe('host capabilities exports', () => {
+  it('exports capability namespaces from the barrel module', () => {
+    expect(HostCall.hostCall).toBeDefined();
+    expect(Crypto.verifyCert).toBeDefined();
+    expect(CertificateUtils.fromString).toBeDefined();
+    expect(Kubernetes.getResource).toBeDefined();
+    expect(Network.dnsLookup).toBeDefined();
+    expect(Manifest.getOCIManifest).toBeDefined();
+    expect(ManifestConfig.getOCIManifestAndConfig).toBeDefined();
+    expect(ManifestDigest.getOCIManifestDigest).toBeDefined();
+    expect(OciSignatureVerifier.verifyPubKeysImage).toBeDefined();
+  });
+});

--- a/js/kubewarden/host_capabilities/index.ts
+++ b/js/kubewarden/host_capabilities/index.ts
@@ -1,33 +1,9 @@
-import { readInput } from '../../protocol';
-
-// this function is provided by the Kubewarden Javy plugin
-declare function __hostCall(binding: string, ns: string, op: string, payload: ArrayBuffer): boolean;
-
-export namespace HostCall {
-  /**
-   * Makes a host call with the specified binding, namespace, operation, and payload.
-   *
-   * @param {string} binding - The binding to use for the host call.
-   * @param {string} ns - The namespace for the host call.
-   * @param {string} op - The operation to perform in the host call.
-   * @param {ArrayBuffer} payload - The payload to send with the host call.
-   * @returns {Uint8Array} - The response from the host call.
-   * @throws {Error} - Throws an error if the host call is unsuccessful.
-   */
-  export function hostCall(
-    binding: string,
-    ns: string,
-    op: string,
-    payload: ArrayBuffer,
-  ): Uint8Array {
-    const isSuccessful = __hostCall(binding, ns, op, payload);
-    const response = readInput();
-
-    if (!isSuccessful) {
-      const responseText = new TextDecoder('utf-8').decode(response);
-      throw new Error(`Host call failed: ${responseText}`);
-    }
-
-    return response;
-  }
-}
+export { HostCall } from './host_call';
+export { Crypto } from './crypto/crypto';
+export { CertificateUtils } from './crypto/types';
+export { Kubernetes } from './kubernetes/kubernetes';
+export { Network } from './net/network';
+export { Manifest } from './oci/manifest/manifest';
+export { ManifestConfig } from './oci/manifest_config/manifest_config';
+export { ManifestDigest } from './oci/manifest_digest/manifest_digest';
+export { OciSignatureVerifier } from './oci/verify_v2/verifier';

--- a/js/kubewarden/host_capabilities/index.ts
+++ b/js/kubewarden/host_capabilities/index.ts
@@ -25,8 +25,7 @@ export namespace HostCall {
 
     if (!isSuccessful) {
       const responseText = new TextDecoder('utf-8').decode(response);
-      console.error('Host call failed: ', responseText);
-      throw new Error('Host call failed');
+      throw new Error(`Host call failed: ${responseText}`);
     }
 
     return response;

--- a/js/kubewarden/host_capabilities/kubernetes/kubernetes.test.ts
+++ b/js/kubewarden/host_capabilities/kubernetes/kubernetes.test.ts
@@ -1,4 +1,4 @@
-import { HostCall } from '../';
+import { HostCall } from '../host_call';
 
 import { Kubernetes } from './kubernetes';
 import type {
@@ -9,7 +9,7 @@ import type {
 } from './types';
 
 // Mock the HostCall
-jest.mock('../', () => ({
+jest.mock('../host_call', () => ({
   HostCall: {
     hostCall: jest.fn(),
   },

--- a/js/kubewarden/host_capabilities/kubernetes/kubernetes.ts
+++ b/js/kubewarden/host_capabilities/kubernetes/kubernetes.ts
@@ -1,4 +1,4 @@
-import { HostCall } from '../';
+import { HostCall } from '../host_call';
 
 import type {
   GetResourceRequest,

--- a/js/kubewarden/host_capabilities/net/network.ts
+++ b/js/kubewarden/host_capabilities/net/network.ts
@@ -1,4 +1,4 @@
-import { HostCall } from '../index';
+import { HostCall } from '../host_call';
 
 export namespace Network {
   /**

--- a/js/kubewarden/host_capabilities/oci/manifest/manifest.ts
+++ b/js/kubewarden/host_capabilities/oci/manifest/manifest.ts
@@ -1,4 +1,4 @@
-import { HostCall } from '../..';
+import { HostCall } from '../../host_call';
 
 import { OciImageManifestResponse } from './types';
 

--- a/js/kubewarden/host_capabilities/oci/manifest_config/manifest_config.ts
+++ b/js/kubewarden/host_capabilities/oci/manifest_config/manifest_config.ts
@@ -1,4 +1,4 @@
-import { HostCall } from '../..';
+import { HostCall } from '../../host_call';
 
 import type { OciImageManifestAndConfigResponse } from './types';
 

--- a/js/kubewarden/host_capabilities/oci/manifest_digest/manifest_digest.ts
+++ b/js/kubewarden/host_capabilities/oci/manifest_digest/manifest_digest.ts
@@ -1,4 +1,4 @@
-import { HostCall } from '../..';
+import { HostCall } from '../../host_call';
 
 import type { OciManifestResponse } from './types';
 

--- a/js/kubewarden/host_capabilities/oci/verify_v2/verifier.test.ts
+++ b/js/kubewarden/host_capabilities/oci/verify_v2/verifier.test.ts
@@ -1,10 +1,10 @@
-import { HostCall } from '../..';
+import { HostCall } from '../../host_call';
 
 import type { VerificationResponse, KeylessInfo, KeylessPrefixInfo } from './types';
 import { OciSignatureVerifier } from './verifier';
 
 // Mock the HostCall module
-jest.mock('../..', () => ({
+jest.mock('../../host_call', () => ({
   HostCall: {
     hostCall: jest.fn(),
   },

--- a/js/kubewarden/host_capabilities/oci/verify_v2/verifier.ts
+++ b/js/kubewarden/host_capabilities/oci/verify_v2/verifier.ts
@@ -1,4 +1,4 @@
-import { HostCall } from '../..';
+import { HostCall } from '../../host_call';
 
 import type {
   SigstorePubKeyVerifyRequest,

--- a/js/kubewarden/logging/index.ts
+++ b/js/kubewarden/logging/index.ts
@@ -1,0 +1,57 @@
+import { HostCall } from '../host_capabilities';
+
+export namespace Logging {
+  export enum Level {
+    Trace = 'trace',
+    Debug = 'debug',
+    Info = 'info',
+    Warning = 'warning',
+    Error = 'error',
+  }
+
+  export type Fields = Record<string, unknown>;
+
+  /**
+   * Sends a policy log entry to the Kubewarden host.
+   *
+   * The log is propagated through the Kubewarden tracing host capability instead
+   * of writing to stdout or stderr.
+   */
+  export function log(level: Level, context: string, message: string, fields: Fields = {}): void {
+    let payload: ArrayBuffer;
+    try {
+      payload = new TextEncoder().encode(
+        JSON.stringify({
+          ...fields,
+          level,
+          message,
+          context,
+        }),
+      ).buffer;
+    } catch (err) {
+      throw new Error(`Cannot serialize policy log entry: ${err}`);
+    }
+
+    HostCall.hostCall('kubewarden', 'tracing', 'log', payload);
+  }
+
+  export function trace(context: string, message: string, fields: Fields = {}): void {
+    log(Level.Trace, context, message, fields);
+  }
+
+  export function debug(context: string, message: string, fields: Fields = {}): void {
+    log(Level.Debug, context, message, fields);
+  }
+
+  export function info(context: string, message: string, fields: Fields = {}): void {
+    log(Level.Info, context, message, fields);
+  }
+
+  export function warn(context: string, message: string, fields: Fields = {}): void {
+    log(Level.Warning, context, message, fields);
+  }
+
+  export function error(context: string, message: string, fields: Fields = {}): void {
+    log(Level.Error, context, message, fields);
+  }
+}

--- a/js/kubewarden/logging/logging.test.ts
+++ b/js/kubewarden/logging/logging.test.ts
@@ -1,0 +1,83 @@
+import { HostCall } from '../host_capabilities';
+
+import { Logging } from './index';
+
+jest.mock('../host_capabilities', () => ({
+  HostCall: {
+    hostCall: jest.fn(),
+  },
+}));
+
+const mockedHostCall = HostCall.hostCall as jest.MockedFunction<typeof HostCall.hostCall>;
+
+function decodeLastPayload(): Record<string, unknown> {
+  const payload = mockedHostCall.mock.calls[mockedHostCall.mock.calls.length - 1][3];
+  return JSON.parse(new TextDecoder().decode(payload)) as Record<string, unknown>;
+}
+
+describe('Logging', () => {
+  beforeEach(() => {
+    mockedHostCall.mockClear();
+    mockedHostCall.mockReturnValue(new Uint8Array());
+  });
+
+  it('should send log entries through the Kubewarden tracing host capability', () => {
+    Logging.info('demo-policy', 'request accepted', {
+      namespace: 'default',
+      allowed: true,
+    });
+
+    expect(mockedHostCall).toHaveBeenCalledWith(
+      'kubewarden',
+      'tracing',
+      'log',
+      expect.any(ArrayBuffer),
+    );
+    expect(decodeLastPayload()).toEqual({
+      level: 'info',
+      message: 'request accepted',
+      context: 'demo-policy',
+      namespace: 'default',
+      allowed: true,
+    });
+  });
+
+  it('should keep reserved log fields under SDK control', () => {
+    Logging.warn('demo-policy', 'settings ignored', {
+      level: 'debug',
+      message: 'overwritten',
+      context: 'other-context',
+      setting: 'ignoredNamespaces',
+    });
+
+    expect(decodeLastPayload()).toEqual({
+      level: 'warning',
+      message: 'settings ignored',
+      context: 'demo-policy',
+      setting: 'ignoredNamespaces',
+    });
+  });
+
+  it('should expose generic and convenience level helpers', () => {
+    Logging.log(Logging.Level.Trace, 'demo-policy', 'trace message');
+    Logging.debug('demo-policy', 'debug message');
+    Logging.error('demo-policy', 'error message');
+
+    expect(mockedHostCall).toHaveBeenCalledTimes(3);
+    expect(decodeLastPayload()).toEqual({
+      level: 'error',
+      message: 'error message',
+      context: 'demo-policy',
+    });
+  });
+
+  it('should fail before calling the host when log fields cannot be serialized', () => {
+    const fields: Logging.Fields = {};
+    fields.self = fields;
+
+    expect(() => Logging.info('demo-policy', 'bad log entry', fields)).toThrow(
+      'Cannot serialize policy log entry',
+    );
+    expect(mockedHostCall).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add a Logging SDK namespace with structured level helpers that send policy logs through the existing Kubewarden tracing host callback
- export the API from the package entrypoint and document it as the stdout/stderr-safe logging path
- update the demo policy to use the logging API instead of console.error, and remove remaining policy-facing console examples

This uses HostCall.hostCall with kubewarden / tracing / log, which is the callback currently linked by policy-evaluator for WASI policies. I avoided adding a direct wasi:logging WIT import here because current policy-evaluator linking does not expose that import yet.

Fixes #203.

## Testing

- cd js && npm ci
- cd js && npm test
- cd js && npm run type-check
- cd js && npm run lint (passes with existing warnings)
- cd js && npm run format:check
- cd js && npm run build
- cd demo_policy && npm ci
- cd demo_policy && npm run type-check
- cd demo_policy && npm run lint (passes with existing warnings)
- cd demo_policy && npm run build
- cd demo_policy && ./node_modules/.bin/prettier --check main.ts test_scenarios.ts
- git diff --check

## Template note

The separate kubewarden/js-policy-template repository still depends on the published npm package. Updating it to call Logging.* should happen after this SDK change is released, otherwise a template PR would need to point at an unreleased fork/branch to pass a clean install.