### PR TITLE
Add Javy plugin e2e workflow

### DIFF
--- a/.github/workflows/javy-plugin-e2e.yml
+++ b/.github/workflows/javy-plugin-e2e.yml
@@ -16,4 +16,20 @@ name: Javy plugin e2e
 
 jobs:
   e2e-tests:
-    uses: ./.github/workflows/e2e-tests.yml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install dependencies
+        uses: kubewarden/github-actions/policy-gh-action-dependencies@a97c0700ad65b276f15fda9195937bb0db850dcf # v4.6.4
+      - name: Install kwctl
+        uses: kubewarden/github-actions/kwctl-installer@a97c0700ad65b276f15fda9195937bb0db850dcf # v4.6.4
+      - name: Install javy
+        uses: ./.github/actions/javy-installer
+      - name: Build Javy plugin
+        run: make build-plugin
+      - name: Install npm dependencies in js directory
+        run: |
+          cd js
+          npm install
+      - name: Run policy e2e tests
+        run: make -C demo_policy e2e-tests

--- a/.github/workflows/javy-plugin-e2e.yml
+++ b/.github/workflows/javy-plugin-e2e.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    paths:
+      - 'javy-plugin-kubewarden/**'
+      - '.github/actions/javy-installer/**'
+      - '.github/workflows/e2e-tests.yml'
+      - '.github/workflows/javy-plugin-e2e.yml'
+  pull_request:
+    paths:
+      - 'javy-plugin-kubewarden/**'
+      - '.github/actions/javy-installer/**'
+      - '.github/workflows/e2e-tests.yml'
+      - '.github/workflows/javy-plugin-e2e.yml'
+
+name: Javy plugin e2e
+
+jobs:
+  e2e-tests:
+    uses: ./.github/workflows/e2e-tests.yml


### PR DESCRIPTION
## Summary

- add a path-filtered Javy plugin e2e workflow for plugin and Javy installer changes
- reuse the existing e2e workflow so Javy/plugin bump PRs build the plugin and run the policy e2e suite with the same commands as release CI

Fixes #260.

## Testing

- yq e . .github/workflows/javy-plugin-e2e.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/javy-plugin-e2e.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/e2e-tests.yml .github/workflows/javy-plugin-e2e.yml
- git diff --check

I could not run make e2e-tests locally because cargo, javy, kwctl, and bats are not installed in this environment.