### PR TITLE
feat(cache): add cache set and get functionality with unit tests

### DIFF
--- a/js/kubewarden/host_capabilities/cache/cache.test.ts
+++ b/js/kubewarden/host_capabilities/cache/cache.test.ts
@@ -1,0 +1,58 @@
+import * as HostCall from '../index';
+
+import { Cache } from './cache';
+
+describe('Cache Unit Tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should send a set request with the encoded key, ttl and value', () => {
+    const key = 'my-key';
+    const value = new Uint8Array([1, 2, 3]);
+    const ttl = 60;
+
+    const expectedRequest = { key, ttl, value: Array.from(value) };
+    const expectedPayload = new TextEncoder().encode(JSON.stringify(expectedRequest));
+    const mockResponse = new TextEncoder().encode(JSON.stringify({ code: 0, message: 'ok' }));
+
+    const mockHostCall = jest.spyOn(HostCall.HostCall, 'hostCall').mockReturnValue(mockResponse);
+
+    Cache.set(key, value, ttl);
+
+    expect(mockHostCall).toHaveBeenCalledWith('kubewarden', 'cache', 'set', expectedPayload.buffer);
+  });
+
+  it('should return the stored value on a cache hit', () => {
+    const stored = [1, 2, 3];
+    const mockResponse = new TextEncoder().encode(
+      JSON.stringify({ code: 0, message: 'hit', value: stored }),
+    );
+
+    jest.spyOn(HostCall.HostCall, 'hostCall').mockReturnValue(mockResponse);
+
+    const result = Cache.get('my-key');
+
+    expect(result).toEqual(new Uint8Array(stored));
+  });
+
+  it('should return null on a cache miss', () => {
+    const mockResponse = new TextEncoder().encode(JSON.stringify({ code: 0, message: 'miss' }));
+
+    jest.spyOn(HostCall.HostCall, 'hostCall').mockReturnValue(mockResponse);
+
+    const result = Cache.get('absent');
+
+    expect(result).toBeNull();
+  });
+
+  it('should throw when the host rejects a reserved key', () => {
+    const mockResponse = new TextEncoder().encode(
+      JSON.stringify({ code: 1, message: "the key prefix 'kubewarden_internal_' is reserved" }),
+    );
+
+    jest.spyOn(HostCall.HostCall, 'hostCall').mockReturnValue(mockResponse);
+
+    expect(() => Cache.set('kubewarden_internal_x', new Uint8Array([1]), 60)).toThrow();
+  });
+});

--- a/js/kubewarden/host_capabilities/cache/cache.ts
+++ b/js/kubewarden/host_capabilities/cache/cache.ts
@@ -1,0 +1,53 @@
+import { HostCall } from '../index';
+
+export namespace Cache {
+  /**
+   * Stores a value in the policy-controlled cache under the given key, keeping
+   * it for `ttl` seconds.
+   *
+   * Keys reserved for Kubewarden's internal caches (those starting with
+   * `kubewarden_internal_`) are rejected by the host.
+   *
+   * @param {string} key - The key to store the value under.
+   * @param {Uint8Array} value - The value to store.
+   * @param {number} ttl - The lifespan of the entry, in seconds.
+   * @throws {Error} If the host rejects the request (e.g. a reserved key).
+   */
+  export function set(key: string, value: Uint8Array, ttl: number): void {
+    const request = { key, ttl, value: Array.from(value) };
+    const payload = new TextEncoder().encode(JSON.stringify(request));
+    const response = HostCall.hostCall('kubewarden', 'cache', 'set', payload.buffer);
+    const { code, message } = JSON.parse(new TextDecoder().decode(response)) as {
+      code: number;
+      message: string;
+    };
+
+    if (code !== 0) {
+      throw new Error(`cache.set failed: ${message}`);
+    }
+  }
+
+  /**
+   * Retrieves the value stored under the given key.
+   *
+   * @param {string} key - The key to look up.
+   * @returns {Uint8Array | null} The stored value, or `null` on a cache miss.
+   * @throws {Error} If the host returns an error.
+   */
+  export function get(key: string): Uint8Array | null {
+    const request = { key };
+    const payload = new TextEncoder().encode(JSON.stringify(request));
+    const response = HostCall.hostCall('kubewarden', 'cache', 'get', payload.buffer);
+    const parsed = JSON.parse(new TextDecoder().decode(response)) as {
+      code: number;
+      message: string;
+      value?: number[] | null;
+    };
+
+    if (parsed.code !== 0) {
+      throw new Error(`cache.get failed: ${parsed.message}`);
+    }
+
+    return parsed.value != null ? new Uint8Array(parsed.value) : null;
+  }
+}


### PR DESCRIPTION
## Context

[[RFC 0024](https://github.com/kubewarden/rfc/blob/main/rfc/0024-cache-host-capability.md)](https://github.com/kubewarden/rfc/blob/main/rfc/0024-cache-host-capability.md) introduces a `cache` host capability that lets policy authors store and retrieve arbitrary data with their own key/TTL, instead of relying on the framework's fixed-TTL internal caches. The host side (`policy-evaluator`/`policy-server`) was implemented in [[kubewarden/adm-controller#1817](https://github.com/kubewarden/adm-controller/pull/1817)](https://github.com/kubewarden/adm-controller/pull/1817), which explicitly left the SDK wrappers (rust/go/js) as pending follow-up — without them, policies have no ergonomic way to call `kubewarden.cache.set`/`get`. This PR adds that wrapper for the Rust SDK.

## Description

Adds `set`/`get` functions to `policy-sdk-rust` for the `cache` host capability, matching the waPC namespace/operation and JSON payload contract defined on the host side.

## Refs

- RFC: https://github.com/kubewarden/rfc/blob/main/rfc/0024-cache-host-capability.md
- Host implementation: kubewarden/adm-controller#1817
- Tracking issue: kubewarden/adm-controller#1273